### PR TITLE
Two updates to the contains method

### DIFF
--- a/lib/Number/Interval.pm
+++ b/lib/Number/Interval.pm
@@ -539,7 +539,7 @@ sub contains {
       if ($self->inc_max) {
 	$contains = 1 if $value <= $max;
       } else {
-	$contains = 1 if $value <= $max;
+	$contains = 1 if $value < $max;
       }
     } elsif (defined $min) {
       if ($self->inc_min) {

--- a/t/interval.t
+++ b/t/interval.t
@@ -3,7 +3,7 @@
 use 5.006;
 use strict;
 use warnings;
-use Test::More tests => 185;
+use Test::More tests => 197;
 
 require_ok( 'Number::Interval' );
 
@@ -68,6 +68,36 @@ ok(!$r->contains( 4 ));
 $r = new Number::Interval( Max => 5 );
 ok(!$r->contains( 6 ));
 ok($r->contains( 4 ));
+
+# IncMin, IncMax contains behavior for non-inverted intervals
+
+$r = new Number::Interval(Min => 4, Max => 8);
+ok(! $r->contains(4), '4  < 4  < 8 is false');
+ok(! $r->contains(8), '4  < 8  < 8 is false');
+
+$r = new Number::Interval(Min => 4, Max => 8, IncMin => 1);
+ok(  $r->contains(4), '4 <= 4  < 8 is true');
+ok(! $r->contains(8), '4 <= 8  < 8 is false');
+
+$r = new Number::Interval(Min => 4, Max => 8, IncMax => 1);
+ok(! $r->contains(4), '4  < 4 <= 8 is false');
+ok(  $r->contains(8), '4  < 8 <= 8 is true');
+
+$r = new Number::Interval(Min => 4, Max => 8, IncMin => 1, IncMax => 1);
+ok(  $r->contains(4), '4 <= 4 <= 8 is true');
+ok(  $r->contains(8), '4 <= 8 <= 8 is true');
+
+$r = new Number::Interval(Min => 4);
+ok(! $r->contains(4), '4  < 4 is false');
+
+$r = new Number::Interval(Min => 4, IncMin => 1);
+ok(  $r->contains(4), '4 <= 4 is true');
+
+$r = new Number::Interval(Max => 8);
+ok(! $r->contains(8), '8  < 8 is false');
+
+$r = new Number::Interval(Max => 8, IncMax => 1);
+ok(  $r->contains(8), '8 <= 8 is true');
 
 # Merging
 


### PR DESCRIPTION
The first change is to make the contains method act as documented for ranges where the minimum and maximum values are the same.  It looks like either this change should be applied, so that it does what it says, or the documentation could be updated to reflect the new behavior.  (Single value ranges stringify to ==x which also implies they should match that value.)  UKIRT fault 20131213.003 is still open due to the problem with single-value ranges.

While reading the contains method I also noticed that the conditions for a maximum-only interval didn't look quite right, so the second change is to introduce a test and fix for this.

I'm not sure whether the OMP depends on either of these things.  I suspected it might use the single-value range feature, which was why I didn't close fault 20131213.003 already, but I hope it doesn't rely on the weird behavior for maximum-only intervals.
